### PR TITLE
Improved in-memory queues, wrote ping system, wrote mute system

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
   "memory": {
     "maxStatQueue": 15
   },
+  "maxPings": 2,
   "roleTranslations": {
       "Administrator": 4,
       "Advisor": 14,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2229,8 +2229,7 @@
     "moment": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "dev": true
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "moment-timezone": {
       "version": "0.5.31",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "discord.js": "^12.4.1",
     "enmap": "^5.8.0",
     "file-type": "^16.0.0",
+    "moment": "^2.29.1",
     "mongoose": "^5.10.11",
     "node-fetch": "^2.6.1",
     "path": "^0.12.7",

--- a/src/modules/events/message.js
+++ b/src/modules/events/message.js
@@ -5,6 +5,8 @@ const getArgs = require('../functions/general/argTranslations')
 const { attemptRoleQueue } = require('../functions/api/v3rm/userSetup')
 const { messageStatQueue } = require('../functions/database/stats')
 const { checkWordFilters } = require('../functions/moderation')
+const { checkPings } = require('../functions/moderation/pingAbuse')
+const { unmuteMembers } = require('../functions/moderation/mute')
 
 const assignRoles = async (message) => {
   const { giuseppeSettings: { channelWelcome } } = message.guild
@@ -49,6 +51,7 @@ const runCommand = (client, message) => {
 const runTasks = async (client, message) => {
   await attemptRoleQueue()
   await messageStatQueue(client, message)
+  await unmuteMembers(message.guild)
 }
 
 module.exports = async (client, message) => {
@@ -61,6 +64,7 @@ module.exports = async (client, message) => {
 
   if (client.secrets.v3rm.api.enabled) assignRoles(message)
   checkWordFilters(client, message)
+  checkPings(client, message)
   runCommand(client, message)
   runTasks(client, message)
 }

--- a/src/modules/events/ready.js
+++ b/src/modules/events/ready.js
@@ -2,6 +2,7 @@
 const Discord = require('discord.js') // eslint-disable-line no-unused-vars
 const mongo = require('../../mongo/connect')
 const log = require('../../mongo/log')
+const { getNextUnmuteMuteTime } = require('../../mongo/mute')
 
 module.exports = async (client) => {
   mongo.connect()
@@ -11,7 +12,15 @@ module.exports = async (client) => {
     .map((g) => mongo.setupOneGuild({ serverId: g.id, serverName: g.name }))
   const resolvedServers = await Promise.all(servers)
   resolvedServers.forEach((s) => {
-    client.guilds.cache.get(s.serverId).giuseppeSettings = s.settings
+    const objData = client.guilds.cache.get(s.serverId)
+    objData.giuseppeSettings = s.settings
+
+    getNextUnmuteMuteTime(s.serverId).then((t) => { objData.giuseppeSettings.nextUnmute = t })
+    objData.giuseppeQueues = {
+      exploit: [],
+      sensitive: [],
+      pingAbuse: [],
+    }
   })
   /* eslint-enable no-param-reassign */
 

--- a/src/modules/functions/api/v3rm/userSetup.js
+++ b/src/modules/functions/api/v3rm/userSetup.js
@@ -40,7 +40,7 @@ const addtoRoleQueue = async (id, member, nickChange, rolesToAdd = []) => {
 // Try to the new role/nickname
 const basicUserSetup = async (details, member) => {
   const rolesToAdd = details.roles.map((role) => member.guild.roles.cache.find((guildRole) => guildRole.name === role && guildRole.name !== 'Member')).filter((r) => !!r)
-  await member.setNickname(member.user.username === details.username ? `${member.user.username}\u200E` : details.username).catch((e) => { throw e })
+  if (details.username) await member.setNickname(member.user.username === details.username ? `${member.user.username}\u200E` : details.username).catch((e) => { throw e })
   if (rolesToAdd.length) await member.roles.add(rolesToAdd).catch((e) => { throw e })
   return member
 }
@@ -59,7 +59,7 @@ const attemptRoleQueue = async () => {
   }, rQ.member).catch(async () => {
     if (rQ.attempts >= 2) {
       // eslint-disable-next-line no-undef
-      await rQ.member.send('There was an unexpected error assigning your roles/nickname, we can\'t let you in the server if we can\'t confirm your v3rm account.').finally(() => { rQ.member.kick('Unable to assign roles').catch((_) => knownErrors.userOperation(_, rQ.member.guild.id)) })
+      await rQ.member.send('There was an unexpected error assigning your roles/nickname, we can\'t let you in the server if we can\'t manage your account.').finally(() => { rQ.member.kick('Unable to assign roles').catch((_) => knownErrors.userOperation(_, rQ.member.guild.id)) })
       failedRoleQueue.shift()
     } else {
       await addtoRoleQueue(rQ.id, rQ.member, rQ.nickChange)

--- a/src/modules/functions/moderation/mute.js
+++ b/src/modules/functions/moderation/mute.js
@@ -1,0 +1,46 @@
+/* eslint-disable no-param-reassign */
+const moment = require('moment')
+const { sendResult } = require('../general')
+const { upsertMute, getAndUnmute, getNextUnmuteMuteTime } = require('../../../mongo/mute')
+const { addtoRoleQueue, attemptRoleQueue } = require('../api/v3rm/userSetup')
+
+let mutedRole = null
+const getMutedRole = (guild) => {
+  if (!mutedRole) {
+    mutedRole = guild.roles.cache.filter((r) => r.name === guild.giuseppeSettings.roleMuted).first()
+    return mutedRole
+  }
+  return mutedRole
+}
+
+const muteMember = async (guild, member, details, message) => {
+  const insertMute = await upsertMute(guild.id, member.user.id, details)
+  await member.roles.add(getMutedRole(guild)).catch(() => {
+    addtoRoleQueue(member.id, member, null, [getMutedRole(guild).name])
+      .then(() => attemptRoleQueue())
+  })
+
+  // Force the settings to update with the next unmute time.
+  guild.giuseppeSettings.nextUnmute = await getNextUnmuteMuteTime(guild.id)
+
+  const mutedUntil = moment().to(insertMute.unmuteTime)
+  sendResult(
+    `Muted <@${member.user.id}>${insertMute.muteReason ? ` for \`${insertMute.muteReason}\`` : ''}.\
+ Unmuting ${mutedUntil}`,
+    { message, timeout: 10000 }, 'User Muted',
+  )
+}
+
+const unmuteMembers = async (guild) => {
+  const { giuseppeSettings: { nextUnmute } } = guild
+  if (nextUnmute === -1 || Date.now() < nextUnmute) return
+  const mutedMembers = getMutedRole(guild).members
+  const mutedIds = mutedMembers.map((m) => m.id)
+  const unmutedMembers = await getAndUnmute(guild.id, mutedIds)
+  mutedMembers.forEach((memb) => {
+    if (unmutedMembers.includes(memb.id)) memb.roles.remove(getMutedRole(guild)).catch(() => {})
+  })
+  guild.giuseppeSettings.nextUnmute = await getNextUnmuteMuteTime(guild.id)
+}
+
+module.exports = { muteMember, unmuteMembers }

--- a/src/modules/functions/moderation/pingAbuse.js
+++ b/src/modules/functions/moderation/pingAbuse.js
@@ -9,7 +9,7 @@ const checkPings = async (client, message) => {
   const nonSelf = message.mentions.users.filter((m) => m.id !== message.author.id)
   if (nonSelf.size <= maxPings) return
   if (inCacheUpsert('pingAbuse', message, 180)) {
-    await muteMember(message.guild, message.member, { muteReason: 'Ping Abuse', unmuteTime: Date.now() + 30000 }, message)
+    await muteMember(message.guild, message.member, { muteReason: 'Ping Abuse' }, message)
     return
   }
 

--- a/src/modules/functions/moderation/pingAbuse.js
+++ b/src/modules/functions/moderation/pingAbuse.js
@@ -1,0 +1,20 @@
+const { sendResult, inCacheUpsert } = require('../general')
+const { muteMember } = require('./mute')
+
+const checkPings = async (client, message) => {
+  let { config: { maxPings } } = client
+  const quotePos = message.cleanContent.indexOf('>')
+  // If they are quoting with ">" or " >"
+  if (quotePos === 0 || quotePos === 1) maxPings += 1
+  const nonSelf = message.mentions.users.filter((m) => m.id !== message.author.id)
+  if (nonSelf.size <= maxPings) return
+  if (inCacheUpsert('pingAbuse', message, 180)) {
+    await muteMember(message.guild, message.member, { muteReason: 'Ping Abuse', unmuteTime: Date.now() + 30000 }, message)
+    return
+  }
+
+  sendResult(`<@${message.author.id}>, you're pinging too many people, please chill out or you'll get muted ☹️`,
+    { message, timeout: 5000 }, 'Chill the fr*ck out dude!')
+}
+
+module.exports = { checkPings }

--- a/src/mongo/mute.js
+++ b/src/mongo/mute.js
@@ -1,0 +1,37 @@
+const mongoose = require('mongoose')
+const log = require('./log')
+const mutedSchema = require('./schemas/muteList')
+
+const Muted = mongoose.model('muteList', mutedSchema)
+
+const upsertMute = async (serverId, id, muteDetails) => {
+  const query = { serverId, id }
+  const theMember = {
+    lastMuted: Date.now(),
+    muteReason: muteDetails.muteReason,
+    unmuteTime: new Date(muteDetails.unmuteTime || Date.now() + 600000),
+  }
+  const options = {
+    upsert: true, new: true, setDefaultsOnInsert: true,
+  }
+
+  const succ = await Muted.findOneAndUpdate(query, {
+    $set: theMember,
+  }, options).catch((err) => log(serverId, 'error', 'Muting Member', err, { id, ...theMember }))
+  return succ
+}
+
+const getNextUnmuteMuteTime = async (serverId) => {
+  const nextUnmute = await Muted.find({ serverId }).sort({ unmuteTime: -1 }).limit(1)
+  return nextUnmute?.[0]?.unmuteTime || -1
+}
+
+const getAndUnmute = async (serverId, ids) => {
+  const now = Date.now()
+  const unmutedMembers = await Muted.find({ serverId, unmuteTime: { $lte: now }, id: { $in: ids } })
+  const unmutedIds = unmutedMembers.map((m) => m.id)
+  await Muted.deleteMany({ id: { $in: unmutedIds } })
+  return unmutedIds || []
+}
+
+module.exports = { upsertMute, getAndUnmute, getNextUnmuteMuteTime }

--- a/src/mongo/schemas/muteList.js
+++ b/src/mongo/schemas/muteList.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose')
+
+const { Schema } = mongoose
+
+const mutedSchema = new Schema({
+  serverId: { type: String },
+  lastMuted: { type: Date, Default: new Date() },
+  unmuteTime: { type: Date },
+  id: { type: String },
+  muteReason: { type: String, Default: null },
+
+})
+
+module.exports = mutedSchema

--- a/src/mongo/schemas/servers.js
+++ b/src/mongo/schemas/servers.js
@@ -15,6 +15,8 @@ const serversSchema = new Schema({
     channelModLog: { type: String, default: 'channellog' },
     channelSlurLog: { type: String, default: 'swore-log' },
     channelStaffVC: { type: String, default: 'Staff' },
+    roleMuted: { type: String, default: 'votemuted' },
+    roleToxic: { type: String, default: 'toxic' },
   },
 })
 


### PR DESCRIPTION
- In memory queues are now handled within the client.giuseppeSettings object.
   - This is done for the pingAbuse cache and the wordFilter caches (sensitive & exploit)
- Wrote a persistent vote mute system using the database. Should be resilient to crashes. Unmutes are performed in a task that is run on message, and an in-memory variable keeps track of when to check the DB for unmutes.
- Wrote ping system, which listens for users pinging too many people twice within a few minute window, warning them the first time.