### PR TITLE
Wrote keeproles

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,5 @@
 {
   "prefix": "!",
-  "v3rmAPI": false,
   "memory": {
     "maxStatQueue": 15
   },

--- a/src/modules/commands/universal/_lookup.js
+++ b/src/modules/commands/universal/_lookup.js
@@ -40,7 +40,7 @@ exports.run = async (client, message, args, type = 'lookup') => { // eslint-disa
 
   const details = await lookup(discordid, editable.guild.id, { bypass: message.member.hasPermission('KICK_MEMBERS'), type }).catch((err) => sendError(err, editable))
   if (!details) return
-  logMember(message.guild.id, message.member, details.uid)
+  logMember(message.guild.id, message.guild.members.cache.get(discordid), details.uid)
 
   const guildMember = editable.guild.members.cache.find((m) => m.id === discordid)
   const kickedMember = updateOrKickMember(guildMember, editable, details)

--- a/src/modules/events/guildMemberAdd.js
+++ b/src/modules/events/guildMemberAdd.js
@@ -1,9 +1,15 @@
 const Discord = require('discord.js') // eslint-disable-line no-unused-vars
 const { basicLookup } = require('../functions/general')
+const { getExtraRoles } = require('../../mongo/members')
 
 /**
  * @param {Discord.Client} client bot client
  */
-module.exports = (client, member) => {
-  if (client.secrets.v3rm.api.enabled) { basicLookup(member) }
+module.exports = async (client, member) => {
+  if (client.secrets.v3rm.api.enabled) basicLookup(member)
+  else {
+    const keepRoles = await getExtraRoles(member.guild.id, member.id)
+    const keepRolesIds = keepRoles.map((r) => r.id)
+    member.roles.add(keepRolesIds).catch(() => {})
+  }
 }

--- a/src/modules/events/guildMemberUpdate.js
+++ b/src/modules/events/guildMemberUpdate.js
@@ -1,0 +1,13 @@
+const Discord = require('discord.js') // eslint-disable-line no-unused-vars
+const { logMember } = require('../functions/database/members')
+
+const sortRoles = (a, b) => a.id - b.id
+const minifyRoles = (r) => r.id
+
+module.exports = (client, oldMember, newMember) => {
+  const oldRoles = oldMember.roles.cache.sort(sortRoles)
+  const newRoles = newMember.roles.cache.sort(sortRoles)
+  if (oldRoles.map(minifyRoles) === newRoles.map(minifyRoles)) return
+
+  logMember(newMember.guild.id, newMember, null, true)
+}

--- a/src/modules/functions/api/v3rm/lookup.js
+++ b/src/modules/functions/api/v3rm/lookup.js
@@ -1,5 +1,6 @@
 const config = require('../../../../../config.json')
 const mongo = require('../../../../mongo/connect')
+const { getExtraRoles } = require('../../../../mongo/members')
 const v3rmApi = require('./apiCall')
 
 const translateRoles = (allGroups) => {
@@ -29,7 +30,11 @@ const lookup = async (discordid, serverId, options) => {
     ...json.additionalgroups.map((_) => parseInt(_, 10)),
   ])
 
-  return { username: json.username, uid: json.uid, roles: translateRoles(allGroups) }
+  const v3rmRoles = translateRoles(allGroups)
+  const keepRoles = await getExtraRoles(serverId, discordid)
+  const keepRolesNames = keepRoles.map((r) => r.name)
+
+  return { username: json.username, uid: json.uid, roles: [...v3rmRoles, ...keepRolesNames] }
 }
 
 module.exports = lookup

--- a/src/modules/functions/database/members.js
+++ b/src/modules/functions/database/members.js
@@ -1,16 +1,29 @@
 const { addMember } = require('../../../mongo/members')
 
-const getUserData = (member, v3rmId = null) => ({
-  displayName: member.displayName,
-  joinedAt: member.joinedAt,
-  tag: member.user.tag,
-  topRoleName: member.roles.highest.name,
-  topRoleColor: member.roles.highest.color,
-  v3rmId,
-})
-
-const logMember = async (server, member, v3rmId = null) => {
-  await addMember(server, member.id, getUserData(member, v3rmId))
+const filterSpecialRoles = (r) => {
+  const { guild: { roles: { everyone: { id } } } } = r
+  const transitions = Object.keys(r.guild.client.config.roleTranslations)
+  return !transitions.includes(r.name) && id !== r.id
 }
 
-module.exports = { getUserData, logMember }
+const getUserData = (member, v3rmId = null, sRoles = false) => {
+  const { roles: { cache } } = member
+  const extraRoles = sRoles ? cache
+    .filter(filterSpecialRoles)
+    .map((r) => ({ id: r.id, name: r.name })) : null
+  return {
+    displayName: member.displayName,
+    joinedAt: member.joinedAt,
+    tag: member.user.tag,
+    topRoleName: member.roles.highest.name,
+    topRoleColor: member.roles.highest.color,
+    extraRoles,
+    v3rmId,
+  }
+}
+
+const logMember = async (server, member, v3rmId = null, sRoles = false) => {
+  await addMember(server, member.id, getUserData(member, v3rmId, sRoles))
+}
+
+module.exports = { getUserData, logMember, filterSpecialRoles }

--- a/src/mongo/members.js
+++ b/src/mongo/members.js
@@ -5,6 +5,11 @@ const membersSchema = require('./schemas/members')
 const Members = mongoose.model('members', membersSchema)
 
 const addMember = async (serverId, id, userData) => {
+  Object.keys(userData).forEach((key) => {
+    // eslint-disable-next-line no-param-reassign
+    if (userData[key] === null) delete userData[key]
+  })
+
   const query = { serverId, id }
   const theMember = { lastUpdated: Date.now(), ...userData }
   const options = {
@@ -18,4 +23,10 @@ const addMember = async (serverId, id, userData) => {
   return succ
 }
 
-module.exports = { addMember }
+const getExtraRoles = async (serverId, id) => {
+  const succ = await Members.find({ serverId, id })
+  if (!succ?.[0]) return []
+  return succ?.[0].extraRoles
+}
+
+module.exports = { addMember, getExtraRoles }

--- a/src/mongo/schemas/members.js
+++ b/src/mongo/schemas/members.js
@@ -13,6 +13,7 @@ const membersSchema = new Schema({
   topRole: { type: Object },
   topRoleName: { type: String },
   topRoleColor: { type: Number },
+  extraRoles: { type: Array, Default: [] },
 })
 
 module.exports = membersSchema


### PR DESCRIPTION
Role persistence is now a thing, any role which isn't automatically assigned by joining, or the lookup/updateme commands will not be cleared, and will persist on rejoin. This includes eyebleach, leaderboard loard, toxic, and votemuted.